### PR TITLE
Environment-specific DAG config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,22 @@ on:
         description: The environment to deploy to.
 
 jobs:
+  detect-environments:
+    runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.environments.outputs.result }}
+    steps:
+      - uses: actions/github-script@v6
+        id: environments
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: json
+          script: |
+            if (context.payload?.inputs?.environment) return [context.payload?.inputs?.environment];
+            const {data: {environments}} =
+              await github.request(`GET /repos/${process.env.GITHUB_REPOSITORY}/environments`);
+            return environments.map(e => e.name)  
+
   test:
     runs-on: ubuntu-latest
     env:
@@ -31,12 +47,15 @@ jobs:
           make test
 
   deploy:
-    needs: [test]
     runs-on: ubuntu-latest
-    environment: development
+    needs: [test, detect-environments]
+    strategy:
+      matrix:
+        environment: ${{ fromJSON(needs.detect-environments.outputs.environments) }}
+    environment: ${{ matrix.environment }}
     env:
       AWS_S3_BUCKET: ${{ secrets.DAGS_S3_BUCKET }}
-      ENVIRONMENT: development
+      ENVIRONMENT: ${{ matrix.environment }}
     steps:
       - uses: actions/checkout@v4
 

--- a/bin/collection_schema.py
+++ b/bin/collection_schema.py
@@ -1,0 +1,18 @@
+from enum import Enum
+from typing import List, Union, Dict
+
+from pydantic import BaseModel, StrictStr
+
+
+class CollectionSelection(str, Enum):
+    none = "none"
+    all = "all"
+
+
+class CollectionConfig(BaseModel):
+    development: Union[CollectionSelection, List[StrictStr]]
+    staging: Union[CollectionSelection, List[StrictStr]]
+    production: Union[CollectionSelection, List[StrictStr]]
+
+    def for_env(self, env) -> Union[CollectionSelection, List[StrictStr]]:
+        return self.__dict__[env]

--- a/bin/collection_schema.py
+++ b/bin/collection_schema.py
@@ -7,12 +7,18 @@ from pydantic import BaseModel, StrictStr
 class CollectionSelection(str, Enum):
     none = "none"
     all = "all"
+    explicit = "explicit"
 
 
 class CollectionConfig(BaseModel):
-    development: Union[CollectionSelection, List[StrictStr]]
-    staging: Union[CollectionSelection, List[StrictStr]]
-    production: Union[CollectionSelection, List[StrictStr]]
+    selection: CollectionSelection
+    collections: List[StrictStr] = []
 
-    def for_env(self, env) -> Union[CollectionSelection, List[StrictStr]]:
+
+class Environments(BaseModel):
+    development: CollectionConfig
+    staging: CollectionConfig
+    production: CollectionConfig
+
+    def for_env(self, env) -> CollectionConfig:
         return self.__dict__[env]

--- a/bin/generate_dag_config.py
+++ b/bin/generate_dag_config.py
@@ -1,21 +1,30 @@
-import tempfile
-import urllib.request
 import csv
 import json
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import List
+
 import click
 
-from pathlib import Path
+from collection_schema import CollectionConfig, CollectionSelection
 
-# variabkle to contain the local colections we want to set up limited 
-DEVELOPMENT_COLLECTIONS = [
-    'ancient-woodland',
-    'organisation',
-    'title-boundary',
-    'article-4-direction',
-    'central-activities-zone'
-]
+collection_config = CollectionConfig(
+    development=[
+        'ancient-woodland',
+        'organisation',
+        'title-boundary',
+        'article-4-direction',
+        'central-activities-zone'
+    ],
+    staging=CollectionSelection.all,
+    production=CollectionSelection.none
+)
 
-STAGING_COLLECTIONS = DEVELOPMENT_COLLECTIONS
+
+def collection_enabled(collection, env):
+    env_collection_config = collection_config.for_env(env)
+    return env_collection_config == CollectionSelection.all or collection in env_collection_config
 
 
 @click.command()
@@ -31,27 +40,23 @@ STAGING_COLLECTIONS = DEVELOPMENT_COLLECTIONS
     default="development",
     help="environment that the json is being created for. If development then a subset of collections are used",
 )
-def make_colection_config(output_path:Path,env: str):
-    config_dict = {}
-    config_dict['env'] = env
-    collections_dict = {}
-    if env == 'development':
-        restricted_collections = DEVELOPMENT_COLLECTIONS
-    elif env == 'staging':
-        restricted_collections = STAGING_COLLECTIONS
-    else:
-        restricted_collections = None
+def make_dag_config(output_path: Path, env: str):
+    config_dict = {'env': env}
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        dataset_spec_url = 'https://raw.githubusercontent.com/digital-land/specification/main/specification/dataset.csv'
         spec_dataset_path = Path(tmpdir) / 'dataset.csv'
-        urllib.request.urlretrieve('https://raw.githubusercontent.com/digital-land/specification/main/specification/dataset.csv',Path(tmpdir) / 'dataset.csv')
+        urllib.request.urlretrieve(dataset_spec_url, Path(tmpdir) / 'dataset.csv')
 
-        with open(spec_dataset_path,newline="") as f:
+        collections_dict = {}
+
+        with open(spec_dataset_path, newline="") as f:
             dictreader = csv.DictReader(f)
             for row in dictreader:
-                collection = row.get('collection',None)
-                if restricted_collections is None or collection in restricted_collections:
-                    dataset = row.get('dataset',None)
+                collection = row.get('collection', None)
+
+                if collection_enabled(collection, env):
+                    dataset = row.get('dataset', None)
                     if collection and dataset:
                         if config_dict.get(collection,None):
                             collections_dict[collection].append(dataset)
@@ -59,8 +64,9 @@ def make_colection_config(output_path:Path,env: str):
                             collections_dict[collection] = [dataset]
 
         config_dict['collections'] = collections_dict
-        with open(output_path,'w') as f:
-            json.dump(config_dict,f,indent=4)
+        with open(output_path, 'w') as f:
+            json.dump(config_dict, f, indent=4)
+
 
 if __name__ == "__main__":
-    make_colection_config()
+    make_dag_config()

--- a/dags/collection_generator.py
+++ b/dags/collection_generator.py
@@ -69,6 +69,7 @@ def configure_dag(**kwargs):
 
     # Push values to XCom
     ti = kwargs['ti']
+    ti.xcom_push(key='env', value=config['env'])
     ti.xcom_push(key='aws_vpc_config', value=aws_vpc_config)
     ti.xcom_push(key='memory', value=memory)
     ti.xcom_push(key='cpu', value=cpu)
@@ -90,8 +91,8 @@ for collection, datasets in config['collections'].items():
         params={
             "cpu": Param(default=8192, type="integer"),
             "memory": Param(default=32768, type="integer"),
-            "transformed-jobs":Param(default=8, type="integer"),
-            "dataset-jobs":Param(default=8, type="integer")
+            "transformed-jobs": Param(default=8, type="integer"),
+            "dataset-jobs": Param(default=8, type="integer")
         },
         render_template_as_native_obj=True
     ) as dag:

--- a/tests/acceptance/test_dags_render.py
+++ b/tests/acceptance/test_dags_render.py
@@ -3,6 +3,7 @@ from airflow.models import DagBag
 
 DAG_FOLDER = 'dags'
 
+
 def test_dag_rendering():
     """Test that all DAGs in the DAG bag render correctly without running any tasks."""
     dag_bag = DagBag(dag_folder=DAG_FOLDER, include_examples=False)

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,5 +1,6 @@
 from dags.utils import get_task_log_config
 
+
 def test_get_task_log_config_gets_config_from_aws(ecs_client):
     # Register a task definition
     response = ecs_client.register_task_definition(
@@ -21,8 +22,6 @@ def test_get_task_log_config_gets_config_from_aws(ecs_client):
             }
         ],
     )
-
-    
 
     # get the config
     log_config = get_task_log_config(ecs_client,'test-task')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Implement a variable which defines the target environment name and used to generate environment-specific DAGs.  The source DAG code can then be environment-agnostic.

I’ve made a few tweaks and improvements to the current implementation.  I don’t think any of the DAGs currently have anything environment-sensitive hardcoded. 

One thing I could do is add the concept of an exclude list to handle the hardcoded logic of skipping organisation and title-boundaries in dag_triggers.py

What do you think?

## Related Tickets & Documents

- Ticket Link: https://trello.com/c/Agp3QFQ9/3460-generate-environment-specific-airflow-dag-config

## QA Instructions, Screenshots, Recordings

Run config generation locally, specify different environments and review generated config.json file:

```
ENVIRONMENT=development make dags/config.json
```
```
ENVIRONMENT=staging make dags/config.json
```
```
ENVIRONMENT=production make dags/config.json
```

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: covered by existing tests
- [ ] I need help with writing tests
