### PR TITLE
fix: make pyspark dags use the new dependency archive

### DIFF
--- a/dags/new_collection_generator.py
+++ b/dags/new_collection_generator.py
@@ -226,7 +226,7 @@ for collection, collection_datasets in filtered_collections.items():
                 S3_ENTRY_POINT = f"s3://{S3_BUCKET}/pkg/entry_script/run_main.py"
                 S3_WHEEL_FILE = f"s3://{S3_BUCKET}/pkg/whl_pkg/pyspark_jobs-0.1.0-py3-none-any.whl"
                 S3_LOG_URI = f"s3://{S3_LOG_BUCKET}/"
-                S3_DEPENDENCIES_PATH = f"s3://{S3_BUCKET}/pkg/dependencies/dependencies.zip"
+                S3_DEPENDENCIES_PATH = f"s3://{S3_BUCKET}/pkg/dependencies/environment.tar.gz"
                 S3_DATA_PATH = f"s3://{S3_SOURCE_DATA_PATH}/"
 
                 assemble_emr_task = EmrServerlessStartJobOperator(
@@ -248,10 +248,16 @@ for collection, collection_datasets in filtered_collections.items():
                                 "--parquet-datasets-path",
                                 f"s3://{ENV}-parquet-datasets",
                             ],
-                            "sparkSubmitParameters": f"--jars /usr/lib/spark/jars/postgresql-42.7.4.jar --py-files {S3_WHEEL_FILE},{S3_DEPENDENCIES_PATH} "
-                            "--conf spark.serializer=org.apache.spark.serializer.KryoSerializer "
-                            "--conf spark.kryo.registrator=org.apache.sedona.core.serde.SedonaKryoRegistrator "
-                            "--conf spark.sql.extensions=org.apache.sedona.sql.SedonaSqlExtensions",
+                            "sparkSubmitParameters": (
+                                f"--jars /usr/lib/spark/jars/postgresql-42.7.4.jar "
+                                f"--py-files {S3_WHEEL_FILE} "
+                                f"--archives {S3_DEPENDENCIES_PATH}#environment "
+                                "--conf spark.pyspark.python=./environment/bin/python "
+                                "--conf spark.pyspark.driver.python=./environment/bin/python "
+                                "--conf spark.serializer=org.apache.spark.serializer.KryoSerializer "
+                                "--conf spark.kryo.registrator=org.apache.sedona.core.serde.SedonaKryoRegistrator "
+                                "--conf spark.sql.extensions=org.apache.sedona.sql.SedonaSqlExtensions"
+                            ),
                         }
                     },
                     configuration_overrides={"monitoringConfiguration": {"s3MonitoringConfiguration": {"logUri": S3_LOG_URI}}},


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PR https://github.com/digital-land/pyspark-jobs/pull/56 (https://github.com/digital-land/pyspark-jobs/commit/5d918f5e2c8dc03392ffa6335b615086a15107b5) did a bunch of work moving the dependency build from a plain zip to a venv-pack archive (environment.tar.gz) to support native extensions like pydantic_core. This new pack was referenced it lots of places but looks like the upload script and DAGs were not updated to match, so the new archive was never uploaded to S3 and workers continued loading the stale dependencies.zip via --py-files (which cannot load native extensions).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/airflow-dags/issues/76)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: fix not a new feature
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
