### PR TITLE
fix: force-reprocessing is a None error

### DIFF
--- a/dags/new_collection_generator.py
+++ b/dags/new_collection_generator.py
@@ -69,6 +69,7 @@ for collection, collection_datasets in filtered_collections.items():
             "transform-batch-size": Param(default=200, type="integer"),
             "incremental-loading-override": Param(default=False, type="boolean"),
             "regenerate-log-override": Param(default=False, type="boolean"),
+            "force-reprocessing": Param(default=False, type="boolean"),
         },
         render_template_as_native_obj=True,
         is_paused_upon_creation=False,
@@ -93,6 +94,7 @@ for collection, collection_datasets in filtered_collections.items():
             transform_batch_size = int(kwargs["params"].get("transform-batch-size"))
             incremental_loading_override = bool(kwargs["params"].get("incremental-loading-override"))
             regenerate_log_override = bool(kwargs["params"].get("regenerate-log-override"))
+            force_reprocessing = bool(kwargs["params"].get("force-reprocessing"))
 
             # Push values to XCom
             ti.xcom_push(key="memory", value=memory)
@@ -102,6 +104,7 @@ for collection, collection_datasets in filtered_collections.items():
             ti.xcom_push(key="transform-batch-size", value=transform_batch_size)
             ti.xcom_push(key="incremental-loading-override", value=incremental_loading_override)
             ti.xcom_push(key="regenerate-log-override", value=regenerate_log_override)
+            ti.xcom_push(key="force-reprocessing", value="True" if force_reprocessing else "")
 
             # add collection_data bucket # add collection bucket name
             collection_dataset_bucket_name = kwargs["conf"].get(section="custom", key="collection_dataset_bucket_name")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix to the following error found in the transform step of the pyspark pipelines: 

botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter overrides.containerOverrides[0].environment[9].value, value: None, type: <class 'NoneType'>, valid types: <class 'str'>

(The 9th container over ride is force-reprocessing) - thanks claude!

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: no this is a fix not a new feature.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
