### PR TITLE
feat: add debug flag to build-digital-land-builder

### DIFF
--- a/dags/digital_land_builder.py
+++ b/dags/digital_land_builder.py
@@ -41,6 +41,7 @@ with DAG(
     params={
         "cpu": Param(default=8192, type="integer"),
         "memory": Param(default=32768, type="integer"),
+        "debug": Param(default=False, type="boolean"),
     },
     render_template_as_native_obj=True,
     is_paused_upon_creation=False,
@@ -104,6 +105,20 @@ with DAG(
         ti.xcom_push(key="dataset-jobs", value=dataset_jobs)
         ti.xcom_push(key="incremental-loading-override", value=incremental_loading_override)
         ti.xcom_push(key="regenerate-log-override", value=regenerate_log_override)
+
+        # build entry point arguments for assemble-tasks EMR job
+        debug = bool(params.get("debug", False))
+        tasks_args = [
+            "--env",
+            config["env"],
+            "--collection-data-path",
+            S3_DATA_PATH,
+            "--parquet-datasets-path",
+            f"s3://{config['env']}-parquet-datasets",
+        ]
+        if debug:
+            tasks_args.append("--debug")
+        ti.xcom_push(key="tasks-entry-point-args", value=tasks_args)
 
         # add collection_data bucket # add collection bucket name
         collection_dataset_bucket_name = kwargs["conf"].get(section="custom", key="collection_dataset_bucket_name")
@@ -269,14 +284,7 @@ with DAG(
         job_driver={
             "sparkSubmit": {
                 "entryPoint": S3_TASKS_ENTRY_POINT,
-                "entryPointArguments": [
-                    "--env",
-                    ENV,
-                    "--collection-data-path",
-                    S3_DATA_PATH,
-                    "--parquet-datasets-path",
-                    f"s3://{ENV}-parquet-datasets",
-                ],
+                "entryPointArguments": '{{ task_instance.xcom_pull(task_ids="configure-dag", key="tasks-entry-point-args") }}',
                 "sparkSubmitParameters": f"--py-files {S3_WHEEL_FILE} " "--conf spark.serializer=org.apache.spark.serializer.KryoSerializer",
             }
         },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Now that debug flags are available - this change makes the debug flag available on the build-digital-land-builder dag so it can be run with debug calculations on request.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/pyspark-jobs/issues/59)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: just applying existing functionality to a new dag not a new function.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
