### PR TITLE
feat: apply new availablibity field to dag generation

### DIFF
--- a/dags/collection_generator.py
+++ b/dags/collection_generator.py
@@ -7,7 +7,16 @@ from airflow.providers.amazon.aws.operators.ecs import (
     EcsRunTaskOperator,
 )
 from airflow.providers.slack.notifications.slack import send_slack_notification
-from utils import dag_default_args, get_collections_dict, get_config, get_transform_batch_configs, load_specification_datasets, push_log_variables, push_vpc_config
+from utils import (
+    dag_default_args,
+    filter_collections_for_env,
+    get_collections_dict,
+    get_config,
+    get_transform_batch_configs,
+    load_specification_datasets,
+    push_log_variables,
+    push_vpc_config,
+)
 
 # read config from file and environment
 config = get_config()
@@ -22,6 +31,7 @@ tiles_builder_container_name = f"{config['env']}-tile-builder"
 
 datasets_dict = load_specification_datasets()
 collections = get_collections_dict(datasets_dict.values())
+collections = filter_collections_for_env(collections, datasets_dict, config["env"])
 
 failure_callbacks = []
 if config["env"] == "production":

--- a/dags/dag_triggers.py
+++ b/dags/dag_triggers.py
@@ -10,7 +10,7 @@ from airflow import DAG
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.trigger_rule import TriggerRule
 from collection_schema import CollectionSelection
-from utils import get_collections_dict, get_config, load_specification_datasets, sort_collections_dict
+from utils import filter_collections_for_env, get_collections_dict, get_config, load_specification_datasets, sort_collections_dict
 
 config = get_config()
 dag_schedule = config.get("schedule", None)  # Use "None" as a fallback if "schedule" key is missing
@@ -28,7 +28,10 @@ def collection_selected(collection_name, configuration):
 
 
 datasets_dict = load_specification_datasets()
-collections = sort_collections_dict(get_collections_dict(datasets_dict.values()))
+collections = get_collections_dict(datasets_dict.values())
+collections = filter_collections_for_env(collections, datasets_dict, config["env"])
+collections = sort_collections_dict(collections)
+
 
 with DAG(
     dag_id="trigger-collection-dags-scheduled",

--- a/dags/new_collection_generator.py
+++ b/dags/new_collection_generator.py
@@ -15,7 +15,16 @@ from airflow.providers.amazon.aws.operators.emr import EmrServerlessStartJobOper
 from airflow.providers.slack.notifications.slack import send_slack_notification
 from airflow.utils.task_group import TaskGroup
 from emr_dags_utils import get_secrets
-from utils import dag_default_args, get_collections_dict, get_config, get_transform_batch_configs, load_specification_datasets, push_log_variables, push_vpc_config
+from utils import (
+    dag_default_args,
+    filter_collections_for_env,
+    get_collections_dict,
+    get_config,
+    get_transform_batch_configs,
+    load_specification_datasets,
+    push_log_variables,
+    push_vpc_config,
+)
 
 # read config from file and environment
 config = get_config()
@@ -33,6 +42,7 @@ collections = get_collections_dict(datasets_dict.values())
 
 
 filtered_collections = {k: v for k, v in collections.items() if k in ["central-activities-zone", "transport-access-node", "title-boundary"]}
+filtered_collections = filter_collections_for_env(filtered_collections, datasets_dict, config["env"])
 
 # read config from file and environment
 config = get_config()

--- a/dags/utils.py
+++ b/dags/utils.py
@@ -62,6 +62,41 @@ def get_collections_dict(datasets):
     return collections_dict
 
 
+def is_dataset_available(dataset, env):
+    """
+    Given a dataset row (with an 'availability' value of '', 'development',
+    'staging' or 'production') and an environment name, return True if the
+    dataset should be available in that environment.
+    """
+    availability = dataset.get("availability", "")
+
+    if availability == "production":
+        return True
+
+    if availability == "staging":
+        return env in ("development", "staging")
+
+    if availability == "development":
+        return env == "development"
+
+    return False
+
+
+def filter_collections_for_env(collections_dict, datasets_dict, env):
+    """
+    Given a dict of collection -> [dataset names] and a dict of dataset name -> dataset row,
+    return a new dict containing only:
+      - collections where at least one dataset is available in env
+      - and for those collections, only the datasets that are themselves available in env
+    """
+    filtered = {}
+    for collection, dataset_names in collections_dict.items():
+        available_datasets = [name for name in dataset_names if is_dataset_available(datasets_dict[name], env)]
+        if available_datasets:
+            filtered[collection] = available_datasets
+    return filtered
+
+
 def get_task_log_config(ecs_client, task_definition_family):
     """
     returns the log configuration of a task definition stored in aws

--- a/tests/unit/test_utlis.py
+++ b/tests/unit/test_utlis.py
@@ -1,4 +1,6 @@
-from dags.utils import sort_collections_dict
+import pytest
+
+from dags.utils import filter_collections_for_env, is_dataset_available, sort_collections_dict
 
 
 def test_sort_collections_dict_moves_priority_keys_to_front():
@@ -6,3 +8,48 @@ def test_sort_collections_dict_moves_priority_keys_to_front():
     sorted_dict = sort_collections_dict(collections_dict)
     key_list = list(sorted_dict.keys())
     assert key_list[0] == "flood-risk-zone"
+
+
+@pytest.mark.parametrize(
+    "availability,env,expected",
+    [
+        ("production", "development", True),
+        ("production", "staging", True),
+        ("production", "production", True),
+        ("staging", "development", True),
+        ("staging", "staging", True),
+        ("staging", "production", False),
+        ("development", "development", True),
+        ("development", "staging", False),
+        ("development", "production", False),
+        ("", "development", False),
+        ("", "staging", False),
+        ("", "production", False),
+    ],
+)
+def test_is_dataset_available(availability, env, expected):
+    dataset = {"availability": availability}
+    assert is_dataset_available(dataset, env) == expected
+
+
+def test_is_dataset_available_treats_missing_availability_as_unavailable():
+    assert is_dataset_available({}, "development") is False
+
+
+def test_filter_collections_for_env_drops_collections_with_no_available_datasets():
+    collections_dict = {"future-collection": ["future-dataset"]}
+    datasets_dict = {"future-dataset": {"availability": "development"}}
+
+    assert filter_collections_for_env(collections_dict, datasets_dict, "staging") == {}
+
+
+def test_filter_collections_for_env_keeps_collection_when_any_dataset_available():
+    collections_dict = {"organisation": ["local-authority", "new-dataset"]}
+    datasets_dict = {
+        "local-authority": {"availability": "production"},
+        "new-dataset": {"availability": "development"},
+    }
+
+    # collection DAG still exists in staging because local-authority is available there,
+    # but only local-authority's task group is included
+    assert filter_collections_for_env(collections_dict, datasets_dict, "staging") == {"organisation": ["local-authority"]}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

add a new filter during dag generation which checks the environment variable of a dataset and only generates according if the current env is equal or lower than the env set for that dataset. 

production => PROD, STAGING and DEV
staging => STAGING and DEV
development => DEV 


## Why
Currently all datasets get run once they have a `collection` defined for them in the specification repo. This is a bit annoying because new datasets end up in dev, staging and production all at the same time, making new data available before there is time to test anything in DEV or STAGING. 

This change follows on from the changes made to [specification in PR](https://github.com/digital-land/specification/pull/191) and should enable future new datasets to be added only DEV or DEV and STAGING for testing before going to PROD.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2641)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

QA I have done: 
 - deployed to DEV 
   - no import errors 
   - 67 dags before and 67 after deployement
   - 12 datsets within organisation-collection before and after deployment
   - trigger-collection-dags-scheduled in DEV only sets off 4 dags as it should
   - new-collection dags all look fine.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
