### PR TITLE
fix: rename availability to environment

### DIFF
--- a/dags/utils.py
+++ b/dags/utils.py
@@ -64,19 +64,22 @@ def get_collections_dict(datasets):
 
 def is_dataset_available(dataset, env):
     """
-    Given a dataset row (with an 'availability' value of '', 'development',
+    Given a dataset row (with an 'environment' value of '', 'development',
     'staging' or 'production') and an environment name, return True if the
     dataset should be available in that environment.
     """
-    availability = dataset.get("availability", "")
+    # Transitional: prefer the new 'environment' column, fall back to the legacy
+    # 'availability' column so the spec and airflow-dags can be merged in any
+    # order. Drop the fallback once the spec rename is fully rolled out.
+    environment = dataset.get("environment") or dataset.get("availability", "")
 
-    if availability == "production":
+    if environment == "production":
         return True
 
-    if availability == "staging":
+    if environment == "staging":
         return env in ("development", "staging")
 
-    if availability == "development":
+    if environment == "development":
         return env == "development"
 
     return False

--- a/tests/unit/test_utlis.py
+++ b/tests/unit/test_utlis.py
@@ -11,7 +11,7 @@ def test_sort_collections_dict_moves_priority_keys_to_front():
 
 
 @pytest.mark.parametrize(
-    "availability,env,expected",
+    "environment,env,expected",
     [
         ("production", "development", True),
         ("production", "staging", True),
@@ -27,18 +27,24 @@ def test_sort_collections_dict_moves_priority_keys_to_front():
         ("", "production", False),
     ],
 )
-def test_is_dataset_available(availability, env, expected):
-    dataset = {"availability": availability}
+def test_is_dataset_available(environment, env, expected):
+    dataset = {"environment": environment}
     assert is_dataset_available(dataset, env) == expected
 
 
-def test_is_dataset_available_treats_missing_availability_as_unavailable():
+def test_is_dataset_available_treats_missing_environment_as_unavailable():
     assert is_dataset_available({}, "development") is False
+
+
+def test_is_dataset_available_falls_back_to_legacy_availability():
+    # transitional: a row that still only has the old 'availability' key works
+    assert is_dataset_available({"availability": "production"}, "production") is True
+    assert is_dataset_available({"availability": "staging"}, "production") is False
 
 
 def test_filter_collections_for_env_drops_collections_with_no_available_datasets():
     collections_dict = {"future-collection": ["future-dataset"]}
-    datasets_dict = {"future-dataset": {"availability": "development"}}
+    datasets_dict = {"future-dataset": {"environment": "development"}}
 
     assert filter_collections_for_env(collections_dict, datasets_dict, "staging") == {}
 
@@ -46,8 +52,8 @@ def test_filter_collections_for_env_drops_collections_with_no_available_datasets
 def test_filter_collections_for_env_keeps_collection_when_any_dataset_available():
     collections_dict = {"organisation": ["local-authority", "new-dataset"]}
     datasets_dict = {
-        "local-authority": {"availability": "production"},
-        "new-dataset": {"availability": "development"},
+        "local-authority": {"environment": "production"},
+        "new-dataset": {"environment": "development"},
     }
 
     # collection DAG still exists in staging because local-authority is available there,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Refactoring dag generation code to look for both new 'environment' field and keeping in place the test for 'availability' while we cross over. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/digital-land-python/issues/565)
- [Sister PR in specification](https://github.com/digital-land/specification/pull/193)
- Closes #

## QA Instructions, Screenshots, Recordings

QA completed
I have verified spec changes by running airflow-dags' real DAG-generation logic (get_collections_dict + filter_collections_for_env) locally against both the current spec dataset.csv (availability) and the renamed branch CSV (environment), and confirmed the generated collection→dataset maps are identical across development, staging and production.

Unit tests have been updated and continue to pass.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
