### PR TITLE
feat: poll datasette before running reporting task

### DIFF
--- a/dags/digital_land_builder.py
+++ b/dags/digital_land_builder.py
@@ -143,7 +143,7 @@ with DAG(
         # Capture the digital-land hash datasette is serving BEFORE the build, so
         # wait-for-datasette-reload can detect when datasette flips to the freshly-built
         # database. Prod-only (the reporting path that consumes it is prod-only).
-        if config["env"] == "production":
+        if config["env"] in ("production", "staging"):  # TEMP: staging added for sensor test — revert before merge
             prebuild_hash = get_datasette_db_hash("digital-land", base_url=datasette_base_url)
             logger.info("Pre-build datasette digital-land hash: %s", prebuild_hash)
             ti.xcom_push(key="datasette-prebuild-hash", value=prebuild_hash)
@@ -256,6 +256,17 @@ with DAG(
         )
 
         build_digital_land_builder >> wait_for_datasette >> run_reporting_task
+
+    elif config["env"] == "staging":  # TEMP: sensor-only staging test — revert before merge
+        wait_for_datasette = PythonSensor(
+            task_id="wait-for-datasette-reload",
+            python_callable=datasette_has_reloaded,
+            poke_interval=30,
+            timeout=1200,
+            mode="reschedule",
+            dag=dag,
+        )
+        build_digital_land_builder >> wait_for_datasette
 
     # now we want to load the digital land db into postgres using the sqlite innjection task
     postgres_loader_task = EcsRunTaskOperator(

--- a/dags/digital_land_builder.py
+++ b/dags/digital_land_builder.py
@@ -140,14 +140,6 @@ with DAG(
         # push  sqlite_ingestion log variables
         push_log_variables(ti, task_definition_name=reporting_task_name, container_name=reporting_task_container_name, prefix="reporting-task")
 
-        # Capture the digital-land hash datasette is serving BEFORE the build, so
-        # wait-for-datasette-reload can detect when datasette flips to the freshly-built
-        # database. Prod-only (the reporting path that consumes it is prod-only).
-        if config["env"] in ("production", "staging"):  # TEMP: staging added for sensor test — revert before merge
-            prebuild_hash = get_datasette_db_hash("digital-land", base_url=datasette_base_url)
-            logger.info("Pre-build datasette digital-land hash: %s", prebuild_hash)
-            ti.xcom_push(key="datasette-prebuild-hash", value=prebuild_hash)
-
         # push aws vpc config
         push_vpc_config(ti, kwargs["conf"])
 
@@ -194,38 +186,34 @@ with DAG(
 
     build_digital_land_builder >> invalidate_cloudfront_cache_task
 
-    def datasette_has_reloaded(**kwargs):
+    def datasette_is_available(**kwargs):
         """
-        Poke fn for wait-for-datasette-reload. Returns True once datasette is serving a
-        DIFFERENT digital-land hash than it was before the build — i.e. it has picked up
-        the freshly-built database. An unreachable endpoint / missing hash counts as
-        "not ready yet" (datasette briefly refuses connections while it restarts).
+        Poke fn for wait-for-datasette. Returns True once datasette responds and is
+        serving the digital-land database — i.e. it is up and answering queries.
+
+        The reporting task queries datasette over HTTP. Datasette serves immutable
+        files, so it restarts to pick up freshly-built ones, and is briefly unreachable
+        / returns 5xx during that restart — which is what used to make reporting fail.
+        This gates reporting until datasette is back up. get_datasette_db_hash returns
+        None while datasette is down / mid-restart, which we treat as "not ready yet".
         """
-        ti = kwargs["ti"]
-        prebuild_hash = ti.xcom_pull(task_ids="configure-dag", key="datasette-prebuild-hash")
-        current_hash = get_datasette_db_hash("digital-land", base_url=datasette_base_url)
-
-        if current_hash is None:
-            logger.info("datasette not serving a digital-land hash yet (restart/unreachable); waiting")
+        if get_datasette_db_hash("digital-land", base_url=datasette_base_url) is None:
+            logger.info("datasette not responding for digital-land yet (down/mid-restart); waiting")
             return False
-        if current_hash == prebuild_hash:
-            logger.info("datasette still serving pre-build hash %s; waiting for reload", prebuild_hash)
-            return False
-
-        logger.info("datasette reloaded: digital-land hash %s -> %s", prebuild_hash, current_hash)
+        logger.info("datasette is available (serving digital-land)")
         return True
 
     if config["env"] == "production":
 
-        # Wait until datasette has picked up the freshly-built digital-land.sqlite3 before
-        # running reporting (which queries datasette over HTTP). Replaces a fixed 10-min
-        # sleep with a real readiness check; on timeout the task fails (Slack alert fires)
-        # so we never report against stale data.
+        # Wait until datasette is up and answering before running reporting (which queries
+        # datasette over HTTP). Replaces a fixed 10-min sleep whose real purpose was to
+        # avoid hitting datasette while it was mid-restart and returning 5xx. On timeout
+        # the task fails (Slack alert fires) rather than letting reporting run blind.
         wait_for_datasette = PythonSensor(
-            task_id="wait-for-datasette-reload",
-            python_callable=datasette_has_reloaded,
+            task_id="wait-for-datasette",
+            python_callable=datasette_is_available,
             poke_interval=30,
-            timeout=1200,  # 20-min cap (was a fixed 10-min sleep); tune to max acceptable wait
+            timeout=1200,  # 20-min cap (was a fixed 10-min sleep); ample for a datasette restart
             mode="reschedule",  # release the worker slot between checks
             dag=dag,
         )
@@ -256,17 +244,6 @@ with DAG(
         )
 
         build_digital_land_builder >> wait_for_datasette >> run_reporting_task
-
-    elif config["env"] == "staging":  # TEMP: sensor-only staging test — revert before merge
-        wait_for_datasette = PythonSensor(
-            task_id="wait-for-datasette-reload",
-            python_callable=datasette_has_reloaded,
-            poke_interval=30,
-            timeout=1200,
-            mode="reschedule",
-            dag=dag,
-        )
-        build_digital_land_builder >> wait_for_datasette
 
     # now we want to load the digital land db into postgres using the sqlite innjection task
     postgres_loader_task = EcsRunTaskOperator(

--- a/dags/digital_land_builder.py
+++ b/dags/digital_land_builder.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import uuid
 from datetime import timedelta
 
@@ -11,9 +10,10 @@ from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from airflow.providers.amazon.aws.operators.emr import EmrServerlessStartJobOperator
 from airflow.providers.slack.notifications.slack import send_slack_notification
+from airflow.sensors.python import PythonSensor
 from botocore.exceptions import BotoCoreError, ClientError
 from emr_dags_utils import get_secrets
-from utils import dag_default_args, get_config, push_log_variables, push_vpc_config
+from utils import dag_default_args, get_config, get_datasette_db_hash, push_log_variables, push_vpc_config
 
 config = get_config()
 logger = logging.getLogger(__name__)
@@ -26,6 +26,13 @@ sqlite_injection_task_container_name = f"{config['env']}-sqlite-ingestion"
 # reporting-task-definition name
 reporting_task_name = f"{config['env']}-reporting-task"
 reporting_task_container_name = f"{config['env']}-reporting"
+
+# Datasette is deployed per-environment; the readiness check must query THIS env's
+# datasette. Prod has no env subdomain; others are datasette.<env>.planning.data.gov.uk.
+if config["env"] == "production":
+    datasette_base_url = "https://datasette.planning.data.gov.uk"
+else:
+    datasette_base_url = f"https://datasette.{config['env']}.planning.data.gov.uk"
 
 
 failure_callbacks = []
@@ -133,6 +140,14 @@ with DAG(
         # push  sqlite_ingestion log variables
         push_log_variables(ti, task_definition_name=reporting_task_name, container_name=reporting_task_container_name, prefix="reporting-task")
 
+        # Capture the digital-land hash datasette is serving BEFORE the build, so
+        # wait-for-datasette-reload can detect when datasette flips to the freshly-built
+        # database. Prod-only (the reporting path that consumes it is prod-only).
+        if config["env"] == "production":
+            prebuild_hash = get_datasette_db_hash("digital-land", base_url=datasette_base_url)
+            logger.info("Pre-build datasette digital-land hash: %s", prebuild_hash)
+            ti.xcom_push(key="datasette-prebuild-hash", value=prebuild_hash)
+
         # push aws vpc config
         push_vpc_config(ti, kwargs["conf"])
 
@@ -179,15 +194,39 @@ with DAG(
 
     build_digital_land_builder >> invalidate_cloudfront_cache_task
 
+    def datasette_has_reloaded(**kwargs):
+        """
+        Poke fn for wait-for-datasette-reload. Returns True once datasette is serving a
+        DIFFERENT digital-land hash than it was before the build — i.e. it has picked up
+        the freshly-built database. An unreachable endpoint / missing hash counts as
+        "not ready yet" (datasette briefly refuses connections while it restarts).
+        """
+        ti = kwargs["ti"]
+        prebuild_hash = ti.xcom_pull(task_ids="configure-dag", key="datasette-prebuild-hash")
+        current_hash = get_datasette_db_hash("digital-land", base_url=datasette_base_url)
+
+        if current_hash is None:
+            logger.info("datasette not serving a digital-land hash yet (restart/unreachable); waiting")
+            return False
+        if current_hash == prebuild_hash:
+            logger.info("datasette still serving pre-build hash %s; waiting for reload", prebuild_hash)
+            return False
+
+        logger.info("datasette reloaded: digital-land hash %s -> %s", prebuild_hash, current_hash)
+        return True
+
     if config["env"] == "production":
 
-        def delay_execution(**kwargs):
-            time.sleep(600)  # (10 minutes)
-
-        # Add delay before reporting task to ensure datasette consistency
-        wait_before_reporting = PythonOperator(
-            task_id="wait-before-reporting",
-            python_callable=delay_execution,
+        # Wait until datasette has picked up the freshly-built digital-land.sqlite3 before
+        # running reporting (which queries datasette over HTTP). Replaces a fixed 10-min
+        # sleep with a real readiness check; on timeout the task fails (Slack alert fires)
+        # so we never report against stale data.
+        wait_for_datasette = PythonSensor(
+            task_id="wait-for-datasette-reload",
+            python_callable=datasette_has_reloaded,
+            poke_interval=30,
+            timeout=1200,  # 20-min cap (was a fixed 10-min sleep); tune to max acceptable wait
+            mode="reschedule",  # release the worker slot between checks
             dag=dag,
         )
 
@@ -216,7 +255,7 @@ with DAG(
             awslogs_fetch_interval=timedelta(seconds=1),
         )
 
-        build_digital_land_builder >> wait_before_reporting >> run_reporting_task
+        build_digital_land_builder >> wait_for_datasette >> run_reporting_task
 
     # now we want to load the digital land db into postgres using the sqlite innjection task
     postgres_loader_task = EcsRunTaskOperator(

--- a/dags/utils.py
+++ b/dags/utils.py
@@ -86,12 +86,11 @@ def is_dataset_available(dataset, env):
 def get_datasette_db_hash(database, base_url="https://datasette.planning.data.gov.uk", timeout=15):
     """
     Return the content hash datasette is currently serving for `database`, read from
-    /-/databases.json. Datasette serves immutable sqlite files, so this hash only
-    changes when it restarts onto a freshly-synced file — making it a reliable
-    "has the new build landed?" signal.
+    /-/databases.json.
 
     Returns None if datasette is unreachable, returns a non-200, or doesn't list the
-    database (e.g. mid-restart), so callers can treat that as "not ready yet".
+    database (e.g. mid-restart), so callers can use "hash is not None" as a simple
+    "datasette is up and serving this database" availability check.
     """
     try:
         response = requests.get(f"{base_url}/-/databases.json", timeout=timeout)

--- a/dags/utils.py
+++ b/dags/utils.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import boto3
+import requests
 
 # Some useful default args for all DAGs
 dag_default_args = {
@@ -80,6 +81,29 @@ def is_dataset_available(dataset, env):
         return env == "development"
 
     return False
+
+
+def get_datasette_db_hash(database, base_url="https://datasette.planning.data.gov.uk", timeout=15):
+    """
+    Return the content hash datasette is currently serving for `database`, read from
+    /-/databases.json. Datasette serves immutable sqlite files, so this hash only
+    changes when it restarts onto a freshly-synced file — making it a reliable
+    "has the new build landed?" signal.
+
+    Returns None if datasette is unreachable, returns a non-200, or doesn't list the
+    database (e.g. mid-restart), so callers can treat that as "not ready yet".
+    """
+    try:
+        response = requests.get(f"{base_url}/-/databases.json", timeout=timeout)
+        response.raise_for_status()
+        databases = response.json()
+    except (requests.RequestException, ValueError):
+        return None
+
+    for db in databases:
+        if db.get("name") == database:
+            return db.get("hash")
+    return None
 
 
 def filter_collections_for_env(collections_dict, datasets_dict, env):

--- a/tests/unit/test_digital_land_builder.py
+++ b/tests/unit/test_digital_land_builder.py
@@ -5,7 +5,7 @@ import pytest
 from airflow.exceptions import AirflowSkipException
 from botocore.exceptions import ClientError
 
-from dags.digital_land_builder import dag
+from dags.digital_land_builder import dag, datasette_has_reloaded
 
 
 def get_task_callable(task_id):
@@ -61,3 +61,22 @@ def test_invalidate_cloudfront_cache_does_not_raise_when_cloudfront_rejects_inva
     invalidate_cloudfront_cache(dag_run=SimpleNamespace(run_id="test-run"), conf=make_conf("E1234567890ABC"))
 
     create_invalidation.assert_called_once()
+
+
+def make_ti(prebuild_hash):
+    return SimpleNamespace(xcom_pull=Mock(return_value=prebuild_hash))
+
+
+def test_datasette_has_reloaded_true_when_hash_changes(monkeypatch):
+    monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value="new-hash"))
+    assert datasette_has_reloaded(ti=make_ti("old-hash")) is True
+
+
+def test_datasette_has_reloaded_false_when_hash_unchanged(monkeypatch):
+    monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value="same-hash"))
+    assert datasette_has_reloaded(ti=make_ti("same-hash")) is False
+
+
+def test_datasette_has_reloaded_false_when_datasette_unreachable(monkeypatch):
+    monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value=None))
+    assert datasette_has_reloaded(ti=make_ti("old-hash")) is False

--- a/tests/unit/test_digital_land_builder.py
+++ b/tests/unit/test_digital_land_builder.py
@@ -5,7 +5,7 @@ import pytest
 from airflow.exceptions import AirflowSkipException
 from botocore.exceptions import ClientError
 
-from dags.digital_land_builder import dag, datasette_has_reloaded
+from dags.digital_land_builder import dag, datasette_is_available
 
 
 def get_task_callable(task_id):
@@ -63,20 +63,11 @@ def test_invalidate_cloudfront_cache_does_not_raise_when_cloudfront_rejects_inva
     create_invalidation.assert_called_once()
 
 
-def make_ti(prebuild_hash):
-    return SimpleNamespace(xcom_pull=Mock(return_value=prebuild_hash))
+def test_datasette_is_available_true_when_hash_returned(monkeypatch):
+    monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value="some-hash"))
+    assert datasette_is_available() is True
 
 
-def test_datasette_has_reloaded_true_when_hash_changes(monkeypatch):
-    monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value="new-hash"))
-    assert datasette_has_reloaded(ti=make_ti("old-hash")) is True
-
-
-def test_datasette_has_reloaded_false_when_hash_unchanged(monkeypatch):
-    monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value="same-hash"))
-    assert datasette_has_reloaded(ti=make_ti("same-hash")) is False
-
-
-def test_datasette_has_reloaded_false_when_datasette_unreachable(monkeypatch):
+def test_datasette_is_available_false_when_datasette_unreachable(monkeypatch):
     monkeypatch.setattr("dags.digital_land_builder.get_datasette_db_hash", Mock(return_value=None))
-    assert datasette_has_reloaded(ti=make_ti("old-hash")) is False
+    assert datasette_is_available() is False

--- a/tests/unit/test_utlis.py
+++ b/tests/unit/test_utlis.py
@@ -1,6 +1,9 @@
-import pytest
+from unittest.mock import Mock
 
-from dags.utils import filter_collections_for_env, is_dataset_available, sort_collections_dict
+import pytest
+import requests
+
+from dags.utils import filter_collections_for_env, get_datasette_db_hash, is_dataset_available, sort_collections_dict
 
 
 def test_sort_collections_dict_moves_priority_keys_to_front():
@@ -53,3 +56,15 @@ def test_filter_collections_for_env_keeps_collection_when_any_dataset_available(
     # collection DAG still exists in staging because local-authority is available there,
     # but only local-authority's task group is included
     assert filter_collections_for_env(collections_dict, datasets_dict, "staging") == {"organisation": ["local-authority"]}
+
+
+def test_get_datasette_db_hash_returns_hash_for_matching_db(monkeypatch):
+    resp = Mock(raise_for_status=Mock())
+    resp.json = Mock(return_value=[{"name": "digital-land", "hash": "abc"}, {"name": "performance", "hash": "def"}])
+    monkeypatch.setattr("requests.get", Mock(return_value=resp))
+    assert get_datasette_db_hash("digital-land") == "abc"
+
+
+def test_get_datasette_db_hash_returns_none_on_error(monkeypatch):
+    monkeypatch.setattr("requests.get", Mock(side_effect=requests.RequestException))
+    assert get_datasette_db_hash("digital-land") is None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Replace the fixed 10-minute `wait-before-reporting` task in `build-digital-land-builder` (prod only) with a real datasette-availability check.

More detail needs to be added on how it now actually works.



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2724)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

This needs to be pushed to staging, with some temporary code chagnes so that it acutally runs in staging and then checked that it works as intended, before it can be implemented in prod.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
