### PR TITLE
feat: add provision quality emr task to dl-builder-dag

### DIFF
--- a/dags/digital_land_builder.py
+++ b/dags/digital_land_builder.py
@@ -120,9 +120,22 @@ with DAG(
             tasks_args.append("--debug")
         ti.xcom_push(key="tasks-entry-point-args", value=tasks_args)
 
-        # add collection_data bucket # add collection bucket name
+        # add collection_data bucket
         collection_dataset_bucket_name = kwargs["conf"].get(section="custom", key="collection_dataset_bucket_name")
         ti.xcom_push(key="collection-dataset-bucket-name", value=collection_dataset_bucket_name)
+
+        # build entry point arguments for provision-quality EMR job
+        provision_quality_args = [
+            "--env",
+            config["env"],
+            "--collection-data-path",
+            S3_DATA_PATH,
+            "--entity-data-path",
+            f"s3://{collection_dataset_bucket_name}/dataset/",
+        ]
+        if debug:
+            provision_quality_args.append("--debug")
+        ti.xcom_push(key="provision-quality-entry-point-args", value=provision_quality_args)
 
         # push collection-task log variables
         push_log_variables(ti, task_definition_name=digital_land_builder_task_name, container_name=digital_land_builder_task_name, prefix="collection-task")
@@ -254,11 +267,12 @@ with DAG(
     S3_BUCKET = f"{ENV}-pd-batch-jobs-codepackage-bucket"
     S3_LOG_BUCKET = f"{ENV}-pd-batch-jobs-logs-bucket"
     S3_TASKS_ENTRY_POINT = f"s3://{S3_BUCKET}/pkg/entry_script/run_tasks.py"
+    S3_PROVISION_QUALITY_ENTRY_POINT = f"s3://{S3_BUCKET}/pkg/entry_script/run_provision_quality.py"
     S3_WHEEL_FILE = f"s3://{S3_BUCKET}/pkg/whl_pkg/pyspark_jobs-0.1.0-py3-none-any.whl"
     S3_LOG_URI = f"s3://{S3_LOG_BUCKET}/"
     S3_DATA_PATH = f"s3://{ENV}-collection-data/"
 
-    def get_tasks_emr_application_id(**context):
+    def get_emr_application_id(**context):
         env = context["ti"].xcom_pull(task_ids="configure-dag", key="env")
         app_name = f"{env}-pd-batch-emrsl-application"
         client = boto3.client("emr-serverless", region_name="eu-west-2")
@@ -270,16 +284,16 @@ with DAG(
                 return app_id
         raise ValueError(f"EMR application '{app_name}' not found")
 
-    get_tasks_app_id = PythonOperator(
-        task_id="get-tasks-emr-app-id",
-        python_callable=get_tasks_emr_application_id,
+    get_emr_app_id = PythonOperator(
+        task_id="get-emr-app-id",
+        python_callable=get_emr_application_id,
         execution_timeout=timedelta(minutes=2),
         dag=dag,
     )
 
     assemble_tasks_emr_task = EmrServerlessStartJobOperator(
         task_id="assemble-tasks",
-        application_id='{{ task_instance.xcom_pull(task_ids="get-tasks-emr-app-id", key="application_id") }}',
+        application_id='{{ task_instance.xcom_pull(task_ids="get-emr-app-id", key="application_id") }}',
         execution_role_arn=EXECUTION_ROLE_ARN,
         job_driver={
             "sparkSubmit": {
@@ -297,4 +311,26 @@ with DAG(
         execution_timeout=timedelta(hours=3),
     )
 
-    configure_dag_task >> get_tasks_app_id >> assemble_tasks_emr_task
+    configure_dag_task >> get_emr_app_id >> assemble_tasks_emr_task
+
+    provision_quality_emr_task = EmrServerlessStartJobOperator(
+        task_id="provision-quality",
+        application_id='{{ task_instance.xcom_pull(task_ids="get-emr-app-id", key="application_id") }}',
+        execution_role_arn=EXECUTION_ROLE_ARN,
+        job_driver={
+            "sparkSubmit": {
+                "entryPoint": S3_PROVISION_QUALITY_ENTRY_POINT,
+                "entryPointArguments": '{{ task_instance.xcom_pull(task_ids="configure-dag", key="provision-quality-entry-point-args") }}',
+                "sparkSubmitParameters": f"--py-files {S3_WHEEL_FILE} " "--conf spark.serializer=org.apache.spark.serializer.KryoSerializer",
+            }
+        },
+        configuration_overrides={"monitoringConfiguration": {"s3MonitoringConfiguration": {"logUri": S3_LOG_URI}}},
+        name="provision-quality-job",
+        wait_for_completion=True,
+        aws_conn_id="aws_default",
+        waiter_max_attempts=180,
+        waiter_delay=60,
+        execution_timeout=timedelta(hours=3),
+    )
+
+    get_emr_app_id >> provision_quality_emr_task


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is to add a new pyspark job for generating provision-quality to the build-digital-land-builder dag.
It runs simultaneously to assemble-tasks. 

## Why
This is all part of the work to regularly calculate provision quality and make it available.

## Details

- The task hangs off the shared EMR application lookup, so it runs in parallel
  with `assemble-tasks` (and the main build). It reuses the same wheel and
  execution role.
- Writes its three CSVs (`provision-quality`, `dataset-quality`,
  `organisation-quality`) to the collection-data bucket.

## Also

Renames `get-tasks-emr-app-id` → `get-emr-app-id`: that task returns the
environment-wide EMR Serverless application id, now shared by both `assemble-tasks`
and `provision-quality`, so the old tasks-specific name was misleading.



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2771)
- [Related PR](https://github.com/digital-land/pyspark-jobs/pull/74) - the relevant pyspark-job #
- Closes #

## QA Instructions, Screenshots, Recordings

I have run this in staging, all runs without issues.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: mainly just configuring/using airflow and aws functions so no new tests needed.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
