### PR TITLE
fix: bump RAM for listed-building

### DIFF
--- a/dags/collection_generator.py
+++ b/dags/collection_generator.py
@@ -115,6 +115,16 @@ for collection, collection_datasets in collections.items():
             dag=dag,
         )
 
+        # listed-building / tree-preservation-order need a bigger Fargate TASK (not just the container)
+        task_size_override = (
+            {
+                "cpu": '{{ task_instance.xcom_pull(task_ids="configure-dag", key="cpu") | string }}',
+                "memory": '{{ task_instance.xcom_pull(task_ids="configure-dag", key="memory") | string }}',
+            }
+            if collection in ("listed-building", "tree-preservation-order")
+            else {}
+        )
+
         collect_ecs_task = EcsRunTaskOperator(
             task_id=f"{collection}-collect",
             dag=dag,
@@ -123,6 +133,7 @@ for collection, collection_datasets in collections.items():
             task_definition=collection_task_name,
             launch_type="FARGATE",
             overrides={
+                **task_size_override,
                 "containerOverrides": [
                     {
                         "name": collection_task_name,
@@ -151,7 +162,7 @@ for collection, collection_datasets in collections.items():
                             {"name": "REPROCESS", "value": '\'{{ task_instance.xcom_pull(task_ids="configure-dag", key="force-reprocessing") }}\''},
                         ],
                     },
-                ]
+                ],
             },
             network_configuration={"awsvpcConfiguration": '{{ task_instance.xcom_pull(task_ids="configure-dag", key="aws_vpc_config") }}'},
             awslogs_group='{{ task_instance.xcom_pull(task_ids="configure-dag", key="collection-task-log-group") }}',
@@ -198,6 +209,7 @@ for collection, collection_datasets in collections.items():
                 task_definition=collection_task_name,
                 launch_type="FARGATE",
                 overrides={
+                    **task_size_override,
                     "containerOverrides": [
                         {
                             "name": collection_task_name,
@@ -226,7 +238,7 @@ for collection, collection_datasets in collections.items():
                                 {"name": "REGENERATE_LOG_OVERRIDE", "value": '\'{{ task_instance.xcom_pull(task_ids="configure-dag", key="regenerate-log-override") | string }}\''},
                             ],
                         },
-                    ]
+                    ],
                 },
                 network_configuration={"awsvpcConfiguration": '{{ task_instance.xcom_pull(task_ids="configure-dag", key="aws_vpc_config") }}'},
                 awslogs_group='{{ task_instance.xcom_pull(task_ids="configure-dag", key="collection-task-log-group") }}',

--- a/dags/dag_triggers.py
+++ b/dags/dag_triggers.py
@@ -56,8 +56,8 @@ with DAG(
         if collection not in ["organisation"]:
 
             if collection_selected(collection, config):
-                # Set custom CPU for listed-building collection
-                conf = {"cpu": 16384, "transformed-jobs": 16} if collection in ("listed-building", "tree-preservation-order") else {}
+                # Set custom CPU and RAM for listed-building collection
+                conf = {"cpu": 16384, "memory": 65536, "transformed-jobs": 16} if collection in ("listed-building", "tree-preservation-order") else {}
 
                 collection_dag = TriggerDagRunOperator(
                     task_id=f"trigger-{collection}-collection-dag",
@@ -98,8 +98,8 @@ with DAG(
     for collection, datasets in collections.items():
         if collection not in ["organisation"]:
 
-            # Set custom CPU for listed-building collection
-            conf = {"cpu": 16384, "transformed-jobs": 16} if collection in ("listed-building", "tree-preservation-order") else {}
+            # Set custom CPU and RAM for listed-building collection
+            conf = {"cpu": 16384, "memory": 65536, "transformed-jobs": 16} if collection in ("listed-building", "tree-preservation-order") else {}
 
             collection_dag = TriggerDagRunOperator(task_id=f"trigger-{collection}-collection-dag", trigger_dag_id=f"{collection}-collection", wait_for_completion=True, conf=conf)
             collection_tasks.append(collection_dag)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Why has this not been implemented
On Friday the 10th this listed-building failed with the error described below, but after a rerun it actually ran cleanly. Given we are going to move these pipelines to pyspark soon, I've decided to drop this work for now, but keeping the PR in case we see this error again before pyspark can be implemented.

## Description

Add a `memory: 65536` (64 GiB) override to the listed-building / tree-preservation-order
branch in `dag_triggers.py` (both the scheduled and manual master DAGs).

## Why
`listed-building-assemble-and-bake` failed overnight  with a DuckDB out-of-memory error during `load_entities_range`:

    duckdb.duckdb.OutOfMemoryException: failed to pin block of size 4.2 MiB (25.5 GiB/25.5 GiB used)

These two collections already get a CPU bump (16 vCPU) via this branch, but memory stayed at the 32 GiB default, which is the Fargate *minimum* for 16 vCPU. DuckDB caps itself at 80% of container RAM (25.5 GiB) and hit that ceiling. Root cause is data growth (listed-building now ~387k entities)

Raising to 64 GiB gives DuckDB ~51 GiB usable (2× headroom). 16 vCPU permits up to 120 GiB
if we need to go further.

## Which pipelines get affected
- Affects **listed-building and tree-preservation-order** (they share this branch in airflow which gets compute from fargate).



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: we are just configuring airflow not introducing any new features.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
